### PR TITLE
Import modules, hiding symbols

### DIFF
--- a/lib/HsImport/Args.hs
+++ b/lib/HsImport/Args.hs
@@ -15,28 +15,31 @@ import Paths_hsimport (version)
 #endif
 
 data HsImportArgs = HsImportArgs
-   { moduleName    :: String
-   , symbolName    :: String
-   , all           :: Bool
-   , with          :: [String]
-   , qualifiedName :: String
-   , as            :: String
-   , inputSrcFile  :: FilePath
-   , outputSrcFile :: FilePath
+   { moduleName     :: String
+   , symbolName     :: String
+   , hideSymbolName :: String
+   , all            :: Bool
+   , with           :: [String]
+   , qualifiedName  :: String
+   , as             :: String
+   , inputSrcFile   :: FilePath
+   , outputSrcFile  :: FilePath
    } deriving (Data, Typeable, Show, Eq)
 
 
 hsImportArgs :: IO HsImportArgs
 hsImportArgs = cmdArgs $ HsImportArgs
-   { moduleName    = def &= help "The module to import"
-   , symbolName    = def &= help "The symbol to import, if empty, the entire module is imported"
-   , all           = def &= help "All constructors or methods of the symbol should be imported: 'Symbol(..)'"
+   { moduleName     = def &= help "The module to import"
+   , symbolName     = def &= help "The symbol to import, if empty, the entire module is imported"
+   , hideSymbolName = def &= help "The symbol to hide when importing the module, if empty, no symbol is hidden"
+                         &= name "hide" &= name "e"
+   , all            = def &= help "All constructors or methods of the symbol should be imported: 'Symbol(..)'"
                          &= name "all" &= name "a"
-   , with          = def &= help "The constructors or methods of the symbol should be imported: 'Symbol(With)'"
-   , qualifiedName = def &= help "The name to use for a qualified module import"
-   , as            = def &= help "The name to use for an unqualified module import" &= name "as"
-   , outputSrcFile = def &= help "Save modified source file to file, if empty, the source file is modified inplace" &= typFile
-   , inputSrcFile  = def &= args &= typ "SOURCEFILE"
+   , with           = def &= help "The constructors or methods of the symbol should be imported: 'Symbol(With)'"
+   , qualifiedName  = def &= help "The name to use for a qualified module import"
+   , as             = def &= help "The name to use for an unqualified module import" &= name "as"
+   , outputSrcFile  = def &= help "Save modified source file to file, if empty, the source file is modified inplace" &= typFile
+   , inputSrcFile   = def &= args &= typ "SOURCEFILE"
    }
    &= program "hsimport"
    &= summary summaryInfo
@@ -49,14 +52,15 @@ hsImportArgs = cmdArgs $ HsImportArgs
 
 defaultArgs :: HsImportArgs
 defaultArgs = HsImportArgs
-   { moduleName    = def
-   , symbolName    = def
-   , all           = def
-   , with          = def
-   , qualifiedName = def
-   , as            = def
-   , inputSrcFile  = def
-   , outputSrcFile = def
+   { moduleName     = def
+   , symbolName     = def
+   , hideSymbolName = def
+   , all            = def
+   , with           = def
+   , qualifiedName  = def
+   , as             = def
+   , inputSrcFile   = def
+   , outputSrcFile  = def
    }
 
 

--- a/lib/HsImport/Args.hs
+++ b/lib/HsImport/Args.hs
@@ -15,31 +15,31 @@ import Paths_hsimport (version)
 #endif
 
 data HsImportArgs = HsImportArgs
-   { moduleName     :: String
-   , symbolName     :: String
-   , hideSymbolName :: String
-   , all            :: Bool
-   , with           :: [String]
-   , qualifiedName  :: String
-   , as             :: String
-   , inputSrcFile   :: FilePath
-   , outputSrcFile  :: FilePath
+   { moduleName    :: String
+   , symbolName    :: String
+   , hide          :: Bool
+   , all           :: Bool
+   , with          :: [String]
+   , qualifiedName :: String
+   , as            :: String
+   , inputSrcFile  :: FilePath
+   , outputSrcFile :: FilePath
    } deriving (Data, Typeable, Show, Eq)
 
 
 hsImportArgs :: IO HsImportArgs
 hsImportArgs = cmdArgs $ HsImportArgs
-   { moduleName     = def &= help "The module to import"
-   , symbolName     = def &= help "The symbol to import, if empty, the entire module is imported"
-   , hideSymbolName = def &= help "The symbol to hide when importing the module, if empty, no symbol is hidden"
-                         &= name "hide" &= name "e"
-   , all            = def &= help "All constructors or methods of the symbol should be imported: 'Symbol(..)'"
+   { moduleName    = def &= help "The module to import"
+   , symbolName    = def &= help "The symbol to import, if empty, the entire module is imported"
+   , hide          = def &= help "Hide the given symbols in the import"
+                         &= name "hide"
+   , all           = def &= help "All constructors or methods of the symbol should be imported: 'Symbol(..)'"
                          &= name "all" &= name "a"
-   , with           = def &= help "The constructors or methods of the symbol should be imported: 'Symbol(With)'"
-   , qualifiedName  = def &= help "The name to use for a qualified module import"
-   , as             = def &= help "The name to use for an unqualified module import" &= name "as"
-   , outputSrcFile  = def &= help "Save modified source file to file, if empty, the source file is modified inplace" &= typFile
-   , inputSrcFile   = def &= args &= typ "SOURCEFILE"
+   , with          = def &= help "The constructors or methods of the symbol should be imported: 'Symbol(With)'"
+   , qualifiedName = def &= help "The name to use for a qualified module import"
+   , as            = def &= help "The name to use for an unqualified module import" &= name "as"
+   , outputSrcFile = def &= help "Save modified source file to file, if empty, the source file is modified inplace" &= typFile
+   , inputSrcFile  = def &= args &= typ "SOURCEFILE"
    }
    &= program "hsimport"
    &= summary summaryInfo
@@ -52,15 +52,15 @@ hsImportArgs = cmdArgs $ HsImportArgs
 
 defaultArgs :: HsImportArgs
 defaultArgs = HsImportArgs
-   { moduleName     = def
-   , symbolName     = def
-   , hideSymbolName = def
-   , all            = def
-   , with           = def
-   , qualifiedName  = def
-   , as             = def
-   , inputSrcFile   = def
-   , outputSrcFile  = def
+   { moduleName    = def
+   , symbolName    = def
+   , hide          = False
+   , all           = def
+   , with          = def
+   , qualifiedName = def
+   , as            = def
+   , inputSrcFile  = def
+   , outputSrcFile = def
    }
 
 

--- a/lib/HsImport/Args.hs
+++ b/lib/HsImport/Args.hs
@@ -17,7 +17,7 @@ import Paths_hsimport (version)
 data HsImportArgs = HsImportArgs
    { moduleName    :: String
    , symbolName    :: String
-   , hide          :: Bool
+   , hiding        :: Bool
    , all           :: Bool
    , with          :: [String]
    , qualifiedName :: String
@@ -31,8 +31,8 @@ hsImportArgs :: IO HsImportArgs
 hsImportArgs = cmdArgs $ HsImportArgs
    { moduleName    = def &= help "The module to import"
    , symbolName    = def &= help "The symbol to import, if empty, the entire module is imported"
-   , hide          = def &= help "Hide the given symbols in the import"
-                         &= name "hide"
+   , hiding        = def &= help "Hide the given symbols in the import. Toggles whether to hide the given symbols or to use an import list"
+                         &= name "hiding" &= name "H"
    , all           = def &= help "All constructors or methods of the symbol should be imported: 'Symbol(..)'"
                          &= name "all" &= name "a"
    , with          = def &= help "The constructors or methods of the symbol should be imported: 'Symbol(With)'"
@@ -54,7 +54,7 @@ defaultArgs :: HsImportArgs
 defaultArgs = HsImportArgs
    { moduleName    = def
    , symbolName    = def
-   , hide          = False
+   , hiding        = def
    , all           = def
    , with          = def
    , qualifiedName = def

--- a/lib/HsImport/HsImportSpec.hs
+++ b/lib/HsImport/HsImportSpec.hs
@@ -44,14 +44,13 @@ hsImportSpec args
    where
       module_ = ModuleImport { moduleName = Args.moduleName args
                              , qualified  = not . null $ Args.qualifiedName args
+                             , hide       = Args.hide args
                              , as         = find (/= "") [Args.qualifiedName args, Args.as args]
                              }
 
       symbolImport =
          case Args.symbolName args of
-              ""  -> case Args.hideSymbolName args of
-                        "" -> Nothing
-                        name -> Just $ HideSymbol name
+              ""  -> Nothing
 
               name | Args.all args              -> Just $ AllOfSymbol name
                    | ws@(_:_) <- Args.with args -> Just $ SomeOfSymbol name ws

--- a/lib/HsImport/HsImportSpec.hs
+++ b/lib/HsImport/HsImportSpec.hs
@@ -49,7 +49,9 @@ hsImportSpec args
 
       symbolImport =
          case Args.symbolName args of
-              ""  -> Nothing
+              ""  -> case Args.hideSymbolName args of
+                        "" -> Nothing
+                        name -> Just $ HideSymbol name
 
               name | Args.all args              -> Just $ AllOfSymbol name
                    | ws@(_:_) <- Args.with args -> Just $ SomeOfSymbol name ws

--- a/lib/HsImport/HsImportSpec.hs
+++ b/lib/HsImport/HsImportSpec.hs
@@ -9,7 +9,7 @@ import qualified Language.Haskell.Exts as HS
 import qualified HsImport.Args as Args
 import HsImport.Args (HsImportArgs)
 import HsImport.Parse (parseFile)
-import HsImport.SymbolImport (SymbolImport(..))
+import HsImport.SymbolImport (SymbolImport(..), Symbol(..))
 import HsImport.ModuleImport
 import HsImport.Types
 import Data.List (find)
@@ -44,17 +44,18 @@ hsImportSpec args
    where
       module_ = ModuleImport { moduleName = Args.moduleName args
                              , qualified  = not . null $ Args.qualifiedName args
-                             , hide       = Args.hiding args
                              , as         = find (/= "") [Args.qualifiedName args, Args.as args]
                              }
+
+      constructor = if Args.hiding args then Hiding else Import
 
       symbolImport =
          case Args.symbolName args of
               ""  -> Nothing
 
-              name | Args.all args              -> Just $ AllOfSymbol name
-                   | ws@(_:_) <- Args.with args -> Just $ SomeOfSymbol name ws
-                   | otherwise                  -> Just $ Symbol name
+              name | Args.all args              -> Just $ constructor $ AllOf name
+                   | ws@(_:_) <- Args.with args -> Just $ constructor $ SomeOf name ws
+                   | otherwise                  -> Just $ constructor $ Only name
 
       saveToFile =
          case Args.outputSrcFile args of

--- a/lib/HsImport/HsImportSpec.hs
+++ b/lib/HsImport/HsImportSpec.hs
@@ -44,7 +44,7 @@ hsImportSpec args
    where
       module_ = ModuleImport { moduleName = Args.moduleName args
                              , qualified  = not . null $ Args.qualifiedName args
-                             , hide       = Args.hide args
+                             , hide       = Args.hiding args
                              , as         = find (/= "") [Args.qualifiedName args, Args.as args]
                              }
 

--- a/lib/HsImport/ModuleImport.hs
+++ b/lib/HsImport/ModuleImport.hs
@@ -10,6 +10,5 @@ type Name = String
 data ModuleImport = ModuleImport
    { moduleName :: Name       -- ^ the name of the module to import
    , qualified  :: Bool       -- ^ if the module should be imported qualified
-   , hide       :: Bool       -- ^ Whether to hide or import a symbol from a module
    , as         :: Maybe Name -- ^ the module should be imported with this name
    } deriving (Show)

--- a/lib/HsImport/ModuleImport.hs
+++ b/lib/HsImport/ModuleImport.hs
@@ -10,5 +10,6 @@ type Name = String
 data ModuleImport = ModuleImport
    { moduleName :: Name       -- ^ the name of the module to import
    , qualified  :: Bool       -- ^ if the module should be imported qualified
+   , hide       :: Bool       -- ^ Whether to hide or import a symbol from a module
    , as         :: Maybe Name -- ^ the module should be imported with this name
    } deriving (Show)

--- a/lib/HsImport/SymbolImport.hs
+++ b/lib/HsImport/SymbolImport.hs
@@ -1,13 +1,31 @@
 
 module HsImport.SymbolImport
    ( SymbolImport(..)
-   ) where
+   , Symbol(..)
+   , getSymbol
+   , isSymbolImportHidden
+   )
+where
 
 type Name = String
 
 -- | What of the symbol should be imported.
-data SymbolImport
-   = Symbol Name                -- ^ only the symbol should be imported
-   | AllOfSymbol Name           -- ^ all constructors or methods of the symbol should be imported: Symbol(..)
-   | SomeOfSymbol Name [String] -- ^ some constructors or methods of the symbol should be imported: Symbol(X, Y)
+data Symbol
+   = Only Name            -- ^ only the symbol should be imported
+   | AllOf Name           -- ^ all constructors or methods of the symbol should be imported: Symbol(..)
+   | SomeOf Name [String] -- ^ some constructors or methods of the symbol should be imported: Symbol(X, Y)
    deriving (Show)
+
+
+data SymbolImport
+   = Import Symbol
+   | Hiding Symbol
+   deriving (Show)
+
+getSymbol :: SymbolImport -> Symbol
+getSymbol (Hiding s) = s
+getSymbol (Import s) = s
+
+isSymbolImportHidden :: SymbolImport -> Bool
+isSymbolImportHidden (Hiding _) = True
+isSymbolImportHidden (Import _) = False

--- a/lib/HsImport/SymbolImport.hs
+++ b/lib/HsImport/SymbolImport.hs
@@ -10,5 +10,4 @@ data SymbolImport
    = Symbol Name                -- ^ only the symbol should be imported
    | AllOfSymbol Name           -- ^ all constructors or methods of the symbol should be imported: Symbol(..)
    | SomeOfSymbol Name [String] -- ^ some constructors or methods of the symbol should be imported: Symbol(X, Y)
-   | HideSymbol Name        -- ^ Hide a symbol when importing
    deriving (Show)

--- a/lib/HsImport/SymbolImport.hs
+++ b/lib/HsImport/SymbolImport.hs
@@ -10,4 +10,5 @@ data SymbolImport
    = Symbol Name                -- ^ only the symbol should be imported
    | AllOfSymbol Name           -- ^ all constructors or methods of the symbol should be imported: Symbol(..)
    | SomeOfSymbol Name [String] -- ^ some constructors or methods of the symbol should be imported: Symbol(X, Y)
+   | HideSymbol Name        -- ^ Hide a symbol when importing
    deriving (Show)

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -94,6 +94,14 @@ symbolTests = testGroup "Symbol Tests"
    , configTest "SymbolTest30" (HI.defaultConfig { HI.prettyPrint = prettyPrint }) (HI.defaultArgs { HI.moduleName = "X.Y", HI.symbolName = "x" })
    , test "SymbolTest31" $ HI.defaultArgs { HI.moduleName = "Ugah.Blub", HI.symbolName = "d" }
    , test "SymbolTest32" $ HI.defaultArgs { HI.moduleName = "Control.Foo", HI.symbolName = "foo" }
+   , test "SymbolTest33" $ HI.defaultArgs { HI.moduleName = "Control.Monad", HI.symbolName = "mapM_", HI.hiding = True }
+   , test "SymbolTest34" $ HI.defaultArgs { HI.moduleName = "Data.Text", HI.symbolName = "isPrefixOf", HI.hiding = True }
+   , test "SymbolTest35" $ HI.defaultArgs { HI.moduleName = "Data.Text", HI.symbolName = "isInfixOf", HI.hiding = True }
+   , test "SymbolTest36" $ HI.defaultArgs { HI.qualifiedName = "T", HI.moduleName = "Data.Text", HI.symbolName = "isInfixOf", HI.hiding = True }
+   , test "SymbolTest37" $ HI.defaultArgs { HI.moduleName = "Data.Text", HI.symbolName = "Text", HI.all = True, HI.hiding = True }
+   , test "SymbolTest38" $ HI.defaultArgs { HI.moduleName = "Data.Text", HI.symbolName = "Text", HI.with = ["A", "B", "C"], HI.hiding = True }
+   , test "SymbolTest39" $ HI.defaultArgs { HI.moduleName = "Data.Text", HI.symbolName = "Text", HI.all = True, HI.as = "T", HI.hiding = True }
+   , test "SymbolTest40" $ HI.defaultArgs { HI.moduleName = "Data.Text", HI.symbolName = "Text", HI.with = ["A", "B", "C"], HI.as = "T", HI.hiding = True }
    ]
 
 

--- a/tests/goldenFiles/SymbolTest33.hs
+++ b/tests/goldenFiles/SymbolTest33.hs
@@ -1,0 +1,19 @@
+{-# Language PatternGuards #-}
+module Blub
+   ( blub
+   , foo
+   , bar
+   ) where
+import Control.Applicative
+   (r, t, z)
+import Control.Monad hiding (when, mapM_)
+import Ugah.Blub
+   ( a
+   , b
+   , c
+   )
+f :: Int -> Int
+f = (+ 3)
+
+r :: Int -> Int
+r =

--- a/tests/goldenFiles/SymbolTest34.hs
+++ b/tests/goldenFiles/SymbolTest34.hs
@@ -1,0 +1,20 @@
+{-# Language PatternGuards #-}
+module Blub
+   ( blub
+   , foo
+   , bar
+   ) where
+import Control.Applicative
+   (r, t, z)
+import Data.Text (isPrefixOf)
+import Data.Text hiding (isInfixOf, isPrefixOf)
+import Ugah.Blub
+   ( a
+   , b
+   , c
+   )
+f :: Int -> Int
+f = (+ 3)
+
+r :: Int -> Int
+r =

--- a/tests/goldenFiles/SymbolTest35.hs
+++ b/tests/goldenFiles/SymbolTest35.hs
@@ -1,0 +1,19 @@
+{-# Language PatternGuards #-}
+module Blub
+   ( blub
+   , foo
+   , bar
+   ) where
+import Control.Applicative
+   (r, t, z)
+import Data.Text hiding (isInfixOf)
+import Ugah.Blub
+   ( a
+   , b
+   , c
+   )
+f :: Int -> Int
+f = (+ 3)
+
+r :: Int -> Int
+r =

--- a/tests/goldenFiles/SymbolTest36.hs
+++ b/tests/goldenFiles/SymbolTest36.hs
@@ -1,0 +1,20 @@
+{-# Language PatternGuards #-}
+module Blub
+   ( blub
+   , foo
+   , bar
+   ) where
+import Control.Applicative
+   (r, t, z)
+import Ugah.Blub
+   ( a
+   , b
+   , c
+   )
+import qualified Data.Text as T
+import Data.Text hiding (isInfixOf)
+f :: Int -> Int
+f = (+ 3)
+
+r :: Int -> Int
+r =

--- a/tests/goldenFiles/SymbolTest37.hs
+++ b/tests/goldenFiles/SymbolTest37.hs
@@ -1,0 +1,19 @@
+{-# Language PatternGuards #-}
+module Blub
+   ( blub
+   , foo
+   , bar
+   ) where
+import Control.Applicative
+   (r, t, z)
+import Ugah.Blub
+   ( a
+   , b
+   , c
+   )
+import Data.Text hiding (Text(..))
+f :: Int -> Int
+f = (+ 3)
+
+r :: Int -> Int
+r =

--- a/tests/goldenFiles/SymbolTest38.hs
+++ b/tests/goldenFiles/SymbolTest38.hs
@@ -1,0 +1,19 @@
+{-# Language PatternGuards #-}
+module Blub
+   ( blub
+   , foo
+   , bar
+   ) where
+import Control.Applicative
+   (r, t, z)
+import Ugah.Blub
+   ( a
+   , b
+   , c
+   )
+import Data.Text hiding (Text(A, B, C))
+f :: Int -> Int
+f = (+ 3)
+
+r :: Int -> Int
+r =

--- a/tests/goldenFiles/SymbolTest39.hs
+++ b/tests/goldenFiles/SymbolTest39.hs
@@ -1,0 +1,20 @@
+{-# Language PatternGuards #-}
+module Blub
+   ( blub
+   , foo
+   , bar
+   ) where
+import Control.Applicative
+   (r, t, z)
+import Ugah.Blub
+   ( a
+   , b
+   , c
+   )
+import Data.Text as T
+import Data.Text hiding (Text(..))
+f :: Int -> Int
+f = (+ 3)
+
+r :: Int -> Int
+r =

--- a/tests/goldenFiles/SymbolTest40.hs
+++ b/tests/goldenFiles/SymbolTest40.hs
@@ -1,0 +1,20 @@
+{-# Language PatternGuards #-}
+module Blub
+   ( blub
+   , foo
+   , bar
+   ) where
+import Control.Applicative
+   (r, t, z)
+import Ugah.Blub
+   ( a
+   , b
+   , c
+   )
+import Data.Text as T
+import Data.Text hiding (Text(A, B, C))
+f :: Int -> Int
+f = (+ 3)
+
+r :: Int -> Int
+r =

--- a/tests/inputFiles/SymbolTest33.hs
+++ b/tests/inputFiles/SymbolTest33.hs
@@ -1,0 +1,19 @@
+{-# Language PatternGuards #-}
+module Blub
+   ( blub
+   , foo
+   , bar
+   ) where
+import Control.Applicative
+   (r, t, z)
+import Control.Monad hiding (when)
+import Ugah.Blub
+   ( a
+   , b
+   , c
+   )
+f :: Int -> Int
+f = (+ 3)
+
+r :: Int -> Int
+r =

--- a/tests/inputFiles/SymbolTest34.hs
+++ b/tests/inputFiles/SymbolTest34.hs
@@ -1,0 +1,20 @@
+{-# Language PatternGuards #-}
+module Blub
+   ( blub
+   , foo
+   , bar
+   ) where
+import Control.Applicative
+   (r, t, z)
+import Data.Text (isPrefixOf)
+import Data.Text hiding (isInfixOf)
+import Ugah.Blub
+   ( a
+   , b
+   , c
+   )
+f :: Int -> Int
+f = (+ 3)
+
+r :: Int -> Int
+r =

--- a/tests/inputFiles/SymbolTest35.hs
+++ b/tests/inputFiles/SymbolTest35.hs
@@ -1,0 +1,19 @@
+{-# Language PatternGuards #-}
+module Blub
+   ( blub
+   , foo
+   , bar
+   ) where
+import Control.Applicative
+   (r, t, z)
+import Data.Text hiding (isInfixOf)
+import Ugah.Blub
+   ( a
+   , b
+   , c
+   )
+f :: Int -> Int
+f = (+ 3)
+
+r :: Int -> Int
+r =

--- a/tests/inputFiles/SymbolTest36.hs
+++ b/tests/inputFiles/SymbolTest36.hs
@@ -1,0 +1,18 @@
+{-# Language PatternGuards #-}
+module Blub
+   ( blub
+   , foo
+   , bar
+   ) where
+import Control.Applicative
+   (r, t, z)
+import Ugah.Blub
+   ( a
+   , b
+   , c
+   )
+f :: Int -> Int
+f = (+ 3)
+
+r :: Int -> Int
+r =

--- a/tests/inputFiles/SymbolTest37.hs
+++ b/tests/inputFiles/SymbolTest37.hs
@@ -1,0 +1,18 @@
+{-# Language PatternGuards #-}
+module Blub
+   ( blub
+   , foo
+   , bar
+   ) where
+import Control.Applicative
+   (r, t, z)
+import Ugah.Blub
+   ( a
+   , b
+   , c
+   )
+f :: Int -> Int
+f = (+ 3)
+
+r :: Int -> Int
+r =

--- a/tests/inputFiles/SymbolTest38.hs
+++ b/tests/inputFiles/SymbolTest38.hs
@@ -1,0 +1,18 @@
+{-# Language PatternGuards #-}
+module Blub
+   ( blub
+   , foo
+   , bar
+   ) where
+import Control.Applicative
+   (r, t, z)
+import Ugah.Blub
+   ( a
+   , b
+   , c
+   )
+f :: Int -> Int
+f = (+ 3)
+
+r :: Int -> Int
+r =

--- a/tests/inputFiles/SymbolTest39.hs
+++ b/tests/inputFiles/SymbolTest39.hs
@@ -1,0 +1,18 @@
+{-# Language PatternGuards #-}
+module Blub
+   ( blub
+   , foo
+   , bar
+   ) where
+import Control.Applicative
+   (r, t, z)
+import Ugah.Blub
+   ( a
+   , b
+   , c
+   )
+f :: Int -> Int
+f = (+ 3)
+
+r :: Int -> Int
+r =

--- a/tests/inputFiles/SymbolTest40.hs
+++ b/tests/inputFiles/SymbolTest40.hs
@@ -1,0 +1,18 @@
+{-# Language PatternGuards #-}
+module Blub
+   ( blub
+   , foo
+   , bar
+   ) where
+import Control.Applicative
+   (r, t, z)
+import Ugah.Blub
+   ( a
+   , b
+   , c
+   )
+f :: Int -> Int
+f = (+ 3)
+
+r :: Int -> Int
+r =


### PR DESCRIPTION
closes #17.
Works quite well in manual tests. 
However, I am unsure about the command line arguments.

Currently, only either import list or hiding can be used. E.g. if a `-s` and `-e` flag is given, `-s` will win and only an import-list will be used. Using both doesn't make sense though, so maybe this never happens?

Also, we probably should reuse the `SymbolImport` for hiding and import lists, since actually, they can do the same, in my opinion. Therefore, I am proposing adding two separate Datatypes `newtype ImportList = ImportList SymbolImport` and `newtype HidingList = HidingList SymbolImport` instead of adding an additional constructor that some functions care about and some dont.

* [x] Cleanup code.
* [x] Write tests.